### PR TITLE
add `docker` env

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -70,7 +70,7 @@ class ApplicationController < ActionController::Base
   end
 
   def load_artefact
-    unless Rails.env.development? #remove me once I rebuild my vm
+    if !Rails.env.development? && !Rails.env.docker? #remove me once I rebuild my vm
       @artefact = content_api.artefact(APP_SLUG)
       set_slimmer_artefact(@artefact)
     end

--- a/config/environments/docker.rb
+++ b/config/environments/docker.rb
@@ -1,0 +1,69 @@
+TradeTariffFrontend::Application.configure do
+  # Settings specified here will take precedence over those in config/application.rb
+
+  # Code is not reloaded between requests
+  config.cache_classes = true
+
+  # Full error reports are disabled and caching is turned on
+  config.consider_all_requests_local       = false
+  config.action_controller.perform_caching = true
+
+  # Compress JavaScripts and CSS
+  config.assets.compress = true
+
+  # Defaults to Rails.root.join("public/assets")
+  # config.assets.manifest = YOUR_PATH
+
+  # Specifies the header that your server uses for sending files
+  # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for apache
+  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
+
+  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  # config.force_ssl = true
+
+  # See everything in the log (default is :info)
+  # config.log_level = :debug
+
+  # Prepend all log lines with the following tags
+  # config.log_tags = [ :subdomain, :uuid ]
+
+  # Use a different logger for distributed setups
+  # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
+
+  # Use a different cache store in production
+  # config.cache_store = :mem_cache_store
+
+  # Enable serving of images, stylesheets, and JavaScripts from an asset server
+  # config.action_controller.asset_host = "http://assets.example.com"
+
+  # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
+  # config.assets.precompile += %w( tariff-print.css.scss )
+
+  # Disable delivery errors, bad email addresses will be ignored
+  # config.action_mailer.raise_delivery_errors = false
+  # config.action_mailer.delivery_method = :ses
+
+  # Enable threaded mode
+  # config.threadsafe!
+
+  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+  # the I18n.default_locale when a translation can not be found)
+  config.i18n.fallbacks = true
+
+  # Send deprecation notices to registered listeners
+  config.active_support.deprecation = :notify
+
+  # Log the query plan for queries taking more than this (works
+  # with SQLite, MySQL, and PostgreSQL)
+  # config.active_record.auto_explain_threshold_in_seconds = 0.5
+
+  # Host for Trade Tariff API endpoint
+  config.api_host = ENV["TARIFF_API_HOST"] || "http://tariff-api.dev.gov.uk:3018"
+
+  # Enable JSON-style logging
+  # config.logstasher.enabled = true
+  # config.logstasher.logger = Logger.new("#{Rails.root}/log/#{Rails.env}.json.log")
+  # config.logstasher.supress_app_log = true
+
+  config.eager_load = true
+end

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,6 +1,6 @@
 require "raven"
 
 Raven.configure do |config|
-  config.environments = %w[ development ]
+  config.environments = %w[ docker ]
   config.dsn = "https://3bee46b6981347afbf075c2179190c94:1cdaa52a99be454eb995830c1306b811@app.getsentry.com/30337"
 end

--- a/config/initializers/slimmer.rb
+++ b/config/initializers/slimmer.rb
@@ -5,7 +5,7 @@ TradeTariffFrontend::Application.configure do
     config.slimmer.use_cache = true
   end
 
-  if Rails.env.development?
+  if Rails.env.development? || Rails.env.docker?
     config.slimmer.asset_host = ENV["STATIC_DEV"] || "https://assets-origin.preview.alphagov.co.uk"
   end
 end

--- a/startup.sh
+++ b/startup.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+export RAILS_ENV=docker
 bundle install
 bundle exec unicorn -p 3017


### PR DESCRIPTION
- use it by default on `startup.sh` (called by docker containers)
- copied from `production`, uses some caching and it's faster than `development`
- log this env's errors on sentry
