### PR TITLE
Replace Airbrake with Sentry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ gem "puma"
 
 gem "ci_reporter_rspec", "~> 1.0"
 gem "logstasher", "~> 0.6"
-gem "airbrake", "~> 4.3"
 
 gem "coffee-rails", "~> 4.1"
 gem "govuk_frontend_toolkit", "~> 4.10"
@@ -29,11 +28,6 @@ gem "responders", "~> 2.1"
 
 group :development, :test do
   gem "pry-rails"
-end
-
-group :development do
-  gem "capistrano", "~> 3.4"
-  gem "foreman"
 end
 
 group :test do
@@ -54,4 +48,5 @@ end
 group :production do
   gem "therubyracer", "~> 0.12"
   gem "rails_12factor"
+  gem "sentry-raven"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,15 +38,8 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.3.8)
-    airbrake (4.3.0)
-      builder
-      multi_json
     arel (6.0.3)
     builder (3.2.2)
-    capistrano (3.4.0)
-      i18n
-      rake (>= 10.0.0)
-      sshkit (~> 1.3)
     capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -67,7 +60,6 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.9.1)
-    colorize (0.7.5)
     concurrent-ruby (1.0.1)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
@@ -82,8 +74,8 @@ GEM
     factory_girl_rails (4.5.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
-    foreman (0.81.0)
-      thor (~> 0.19.1)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
     forgery (0.6.0)
     gds-api-adapters (23.2.2)
       link_header
@@ -136,9 +128,7 @@ GEM
     minitest (5.8.4)
     multi_json (1.11.2)
     multi_xml (0.5.5)
-    net-scp (1.2.1)
-      net-ssh (>= 2.6.5)
-    net-ssh (2.9.2)
+    multipart-post (2.0.0)
     netrc (0.10.3)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
@@ -233,6 +223,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (~> 1.1)
+    sentry-raven (0.15.6)
+      faraday (>= 0.7.6)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
     simplecov (0.10.0)
@@ -250,10 +242,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sshkit (1.7.1)
-      colorize (>= 0.7.0)
-      net-scp (>= 1.1.2)
-      net-ssh (>= 2.8.0)
     therubyracer (0.12.2)
       libv8 (~> 3.16.14.0)
       ref
@@ -285,13 +273,10 @@ PLATFORMS
 
 DEPENDENCIES
   addressable (~> 2.3)
-  airbrake (~> 4.3)
-  capistrano (~> 3.4)
   capybara (~> 2.4)
   ci_reporter_rspec (~> 1.0)
   coffee-rails (~> 4.1)
   factory_girl_rails
-  foreman
   forgery
   gds-api-adapters (= 23.2.2)
   govspeak (~> 3.4)
@@ -313,6 +298,7 @@ DEPENDENCIES
   rspec-rails (~> 3.2)
   rspec_junit_formatter
   sass-rails (~> 5.0)
+  sentry-raven
   shoulda-matchers
   simplecov (~> 0.10)
   simplecov-rcov (~> 0.2.3)

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,6 +1,0 @@
-Airbrake.configure do |config|
-  config.port    = 443
-  config.secure  = true
-  config.host    = Rails.application.secrets.errbit_host
-  config.api_key = Rails.application.secrets.errbit_api_key
-end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -23,5 +23,3 @@ test:
 production:
   secret_token: <%= ENV["SECRET_TOKEN"] %>
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
-  errbit_host: <%= ENV["ERRBIT_HOST"] %>
-  errbit_api_key: <%= ENV["ERRBIT_API_KEY"] %>


### PR DESCRIPTION
Set your SENTRY_DSN environment variable and the gem will capture and
send exceptions to the Sentry server.

Raven only runs when SENTRY_DSN is set


#### Notes

Remove `capistrano`  and `foreman` gem from the Gemfile