### PR TITLE
The search_reference_presenter will not expect the referenced association

### DIFF
--- a/app/presenters/search_reference_presenter.rb
+++ b/app/presenters/search_reference_presenter.rb
@@ -1,24 +1,19 @@
 class SearchReferencePresenter
-  attr_reader :search_reference, :referenced_entity
-
-  delegate :link, to: :referenced_entity
+  attr_reader :search_reference
 
   def initialize(search_reference)
     @search_reference = search_reference
-    @referenced_entity = presenter_for(
-      search_reference.referenced_entity
-    ).new(search_reference.referenced_entity)
   end
 
   def to_s
     search_reference.title.titleize
   end
 
-  private
-
-  def presenter_for(referenced_entity)
-    "#{referenced_entity.class}Presenter".classify.constantize
+  def link
+    "/#{APP_SLUG}/#{referenced_class.tableize}/#{referenced_id}"
   end
+
+  private
 
   def method_missing(*args, &block)
     @search_reference.send(*args, &block)


### PR DESCRIPTION
#### What this PR does:

The response of the request for Search References has a node called `referenced` which has some expensive operations that make this endpoint slow, but this node is not necessary for the frontend or admin app.

This PR removes the dependency of having this node.