### PR TITLE
Optimize changes pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem "rack-timeout", "~> 0.4"
 
 group :development, :test do
   gem "pry-rails"
+  gem "quiet_assets"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,8 @@ GEM
     pry-rails (0.3.4)
       pry (>= 0.9.10)
     puma (3.4.0)
+    quiet_assets (1.1.0)
+      railties (>= 3.1, < 5.0)
     rack (1.6.4)
     rack-cache (1.2)
       rack (>= 0.4)
@@ -301,6 +303,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.4)
   rack-timeout (~> 0.4)
+  quiet_assets
   rails (= 4.2.5.2)
   rails_12factor
   responders (~> 2.1)

--- a/app/controllers/chapters/changes_controller.rb
+++ b/app/controllers/chapters/changes_controller.rb
@@ -1,5 +1,8 @@
 module Chapters
   class ChangesController < ::ChangesController
+
+    private
+
     def changeable
       @changeable ||= Chapter.find(params[:chapter_id], query_params)
     end

--- a/app/controllers/commodities/changes_controller.rb
+++ b/app/controllers/commodities/changes_controller.rb
@@ -1,7 +1,10 @@
 module Commodities
   class ChangesController < ::ChangesController
+
+    private
+
     def commodity
-      Commodity.find(params[:commodity_id], query_params)
+      @commodity ||= Commodity.find(params[:commodity_id], query_params)
     end
 
     def changeable

--- a/app/controllers/headings/changes_controller.rb
+++ b/app/controllers/headings/changes_controller.rb
@@ -1,7 +1,10 @@
 module Headings
   class ChangesController < ::ChangesController
+
+    private
+
     def heading
-      Heading.find(params[:heading_id], query_params)
+      @heading ||= Heading.find(params[:heading_id], query_params)
     end
 
     def changeable

--- a/app/helpers/commodities_helper.rb
+++ b/app/helpers/commodities_helper.rb
@@ -51,7 +51,7 @@ module CommoditiesHelper
                          title: "Full tariff code: #{commodity.code}",
                          class: 'identifier',
                          'aria-describedby' => "commodity-#{commodity.code}") +
-      content_tag(:span, "#{commodity.to_s.html_safe}".html_safe,
+      content_tag(:span, "#{commodity.to_s.html_safe} (#{link_to('changes', commodity_changes_path(commodity.declarable, format: :atom), class: 'feed')})".html_safe,
                          class: 'description',
                          id: "commodity-#{commodity.code}")
 

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -13,7 +13,7 @@
           <dd>
             <h1>
               <%= link_to  @chapter, chapter_path(@chapter) %>
-              
+              (<%= link_to 'changes', chapter_changes_path(@chapter, format: :atom), class: "feed" %>)
             </h1>
             <dl class="chapter-headings">
               <%= render @headings %>

--- a/app/views/headings/show.html.erb
+++ b/app/views/headings/show.html.erb
@@ -19,6 +19,7 @@
                 <dd>
                   <h1>
                     <%= @heading.formatted_description.html_safe %>
+                    (<%= link_to 'changes', heading_changes_path(@heading.declarable, format: :atom), class: "feed" %>)
                   </h1>
                 <p class="commodity-tree-note"><span>The number following each commodity's </span><em>Description</em><span> is its </span><em class="code">Commodity code</em></p>
                   <ul class="commodities">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,22 +26,22 @@ TradeTariffFrontend::Application.routes.draw do
 
     resources :sections, only: [:index, :show]
     resources :chapters, only: [:index, :show] do
-      # resources :changes,
-      #           only: [:index],
-      #           defaults: { format: :atom },
-      #           module: 'chapters'
+      resources :changes,
+                only: [:index],
+                defaults: { format: :atom },
+                module: 'chapters'
     end
     resources :headings, only: [:index, :show] do
-      # resources :changes,
-      #           only: [:index],
-      #           defaults: { format: :atom },
-      #           module: 'headings'
+      resources :changes,
+                only: [:index],
+                defaults: { format: :atom },
+                module: 'headings'
     end
     resources :commodities, only: [:index, :show] do
-      # resources :changes,
-      #           only: [:index],
-      #           defaults: { format: :atom },
-      #           module: 'commodities'
+      resources :changes,
+                only: [:index],
+                defaults: { format: :atom },
+                module: 'commodities'
     end
   end
 

--- a/lib/api_entity.rb
+++ b/lib/api_entity.rb
@@ -16,7 +16,7 @@ module ApiEntity
     include HTTParty
     include MultiJson
     base_uri Rails.application.config.api_host
-    debug_output if Rails.env.development?
+    # debug_output
 
     attr_reader :attributes
 


### PR DESCRIPTION
#### What this PR does:

This PR restore the changes links and makes a minor optimization memoizing the call to the declarable model.. it's a small change but a big performance improvement since the objects do not live in memory but makes a new request to the external API.

Before:

![before](https://cloud.githubusercontent.com/assets/1143421/17156247/6d55f28e-534e-11e6-8dc8-7a7757d32889.png)

After:

![after](https://cloud.githubusercontent.com/assets/1143421/17156263/81819902-534e-11e6-9f41-faf411a42eb0.png)

#### Notes

To help debugging the logs I've added the `quiet_assets` gem to the development group.

I've also removed the verbosity of the logs, is more distracting than helpful all the info about the connection and response from the backend.
