### PR TITLE
mark commodity’s formatted description as html safe

### DIFF
--- a/app/helpers/commodities_helper.rb
+++ b/app/helpers/commodities_helper.rb
@@ -60,7 +60,7 @@ module CommoditiesHelper
 
   def declarable_heading(commodity)
     content_tag(:h1) do
-      content_tag(:span, commodity,
+      content_tag(:span, commodity.formatted_description.html_safe,
                           class: 'description',
                           id: "commodity-#{commodity.code}")
     end


### PR DESCRIPTION
in declarable’s heading, so that we properly render descriptions