### PR TITLE
do not log smoke requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -79,4 +79,9 @@ class ApplicationController < ActionController::Base
   def bots_no_index_if_historical
     response.headers["X-Robots-Tag"] = "none" unless @search.today?
   end
+
+  def append_info_to_payload(payload)
+    super
+    payload[:user_agent] = request.env["HTTP_USER_AGENT"]
+  end
 end

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,3 +1,5 @@
+require "api_entity"
+
 class HealthcheckController < ActionController::Base
   rescue_from ApiEntity::Error do |e|
     render text: '', status: :error
@@ -5,7 +7,13 @@ class HealthcheckController < ActionController::Base
 
   def check
     # Check API connectivity
-    Section.all
+    Section.all(headers: original_ua_headers)
     render json: { git_sha1: CURRENT_RELEASE_SHA }
+  end
+
+  private
+
+  def original_ua_headers
+    { "X_ORIGINAL_USER_AGENT" => request.env["HTTP_USER_AGENT"] }
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,6 +45,14 @@ TradeTariffFrontend::Application.configure do
       params: event.payload[:params].except('controller', 'action', 'format', 'utf8'),
     }.merge(JSON.parse(ENV['VCAP_APPLICATION']))
   end
+  config.lograge.ignore_custom = lambda do |event, *args|
+    [
+      "Smokey Test / Ruby",
+      "updown.io"
+    ].any? do |ignored_user_agent|
+      event[:payload][:user_agent] == ignored_user_agent
+    end
+  end
 
   # Use a different cache store in production
   config.cache_store = :dalli_store, nil, {


### PR DESCRIPTION
from following user agents:

- Smokey Test / Ruby
- updown.io

also send along client’s original user agent to backend on /healthcheck endpoint. So that the backend ignores smoke requests’ user agents