### PR TITLE
Add attribute rel="nofollow" to changes links

### DIFF
--- a/app/helpers/commodities_helper.rb
+++ b/app/helpers/commodities_helper.rb
@@ -51,7 +51,7 @@ module CommoditiesHelper
                          title: "Full tariff code: #{commodity.code}",
                          class: 'identifier',
                          'aria-describedby' => "commodity-#{commodity.code}") +
-      content_tag(:span, "#{commodity.to_s.html_safe} (#{link_to('changes', commodity_changes_path(commodity.declarable, format: :atom), class: 'feed')})".html_safe,
+      content_tag(:span, "#{commodity.to_s.html_safe} (#{link_to('changes', commodity_changes_path(commodity.declarable, format: :atom), class: 'feed', rel: 'nofollow')})".html_safe,
                          class: 'description',
                          id: "commodity-#{commodity.code}")
 

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -13,7 +13,7 @@
           <dd>
             <h1>
               <%= link_to  @chapter, chapter_path(@chapter) %>
-              (<%= link_to 'changes', chapter_changes_path(@chapter, format: :atom), class: "feed" %>)
+              (<%= link_to 'changes', chapter_changes_path(@chapter, format: :atom), class: "feed", rel: "nofollow" %>)
             </h1>
             <dl class="chapter-headings">
               <%= render @headings %>

--- a/app/views/headings/show.html.erb
+++ b/app/views/headings/show.html.erb
@@ -19,7 +19,7 @@
                 <dd>
                   <h1>
                     <%= @heading.formatted_description.html_safe %>
-                    (<%= link_to 'changes', heading_changes_path(@heading.declarable, format: :atom), class: "feed" %>)
+                    (<%= link_to 'changes', heading_changes_path(@heading.declarable, format: :atom), class: "feed", rel: "nofollow" %>)
                   </h1>
                 <p class="commodity-tree-note"><span>The number following each commodity's </span><em>Description</em><span> is its </span><em class="code">Commodity code</em></p>
                   <ul class="commodities">


### PR DESCRIPTION
#### What this PR does:

Seems we do not have the tariff in the gov.uk robots file, so this PR adds the `rel` attribute to `nofollow` to the atom/changes links to prevent spiders crawling them.