### PR TITLE
Update links to persist the query string

### DIFF
--- a/app/views/chapters/_chapter.html.erb
+++ b/app/views/chapters/_chapter.html.erb
@@ -1,2 +1,2 @@
 <dt class="chapter-code" title="Chapter code"><%= chapter.short_code %></dt>
-<dd><%= link_to chapter, chapter_path(chapter) %></dd>
+<dd><%= link_to chapter, chapter_path(chapter, request.query_parameters.symbolize_keys) %></dd>

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -7,12 +7,12 @@
   <div class="inner">
     <dl>
       <dt class="section-number">Section <%= @chapter.section_numeral %></dt>
-      <dd class="section-title"><%= link_to @chapter.section, section_path(@chapter.section) %>
+      <dd class="section-title"><%= link_to @chapter.section, section_path(@chapter.section, request.query_parameters.symbolize_keys) %>
         <dl class="tariff-fragments">
           <dt class="chapter-code" title="Chapter code"><%= @chapter.short_code %></dt>
           <dd>
             <h1>
-              <%= link_to  @chapter, chapter_path(@chapter) %>
+              <%= link_to  @chapter, chapter_path(@chapter, request.query_parameters.symbolize_keys) %>
               (<%= link_to 'changes', chapter_changes_path(@chapter, format: :atom), class: "feed", rel: "nofollow" %>)
             </h1>
             <dl class="chapter-headings">

--- a/app/views/commodities/_commodity.html.erb
+++ b/app/views/commodities/_commodity.html.erb
@@ -5,13 +5,13 @@
   </li>
 <% else %>
   <li class="<%= commodity_level(commodity)%><%= leaf_position(commodity) %>">
-    <a href="<%= commodity_path(commodity) %>" title="View complete information for this commodity">
-    <span class="description open" id="commodity-<%= commodity.short_code %>"><%= commodity.to_s.html_safe %></span>
+    <%= link_to commodity_path(commodity, request.query_parameters.symbolize_keys), title: "View complete information for this commodity" do %>
+      <span class="description open" id="commodity-<%= commodity.short_code %>"><%= commodity.to_s.html_safe %></span>
       <span class="identifier" aria-describedby="commodity-<%= commodity.short_code %>">
         <span class="chapter-code"><%= commodity.chapter_code %></span>
         <span class="heading-code"><%= commodity.heading_code %></span>
         <%= commodity.display_short_code %>
       </span>
-      </a>
+    <% end %>
   </li>
 <% end %>

--- a/app/views/declarables/_declarable.html.erb
+++ b/app/views/declarables/_declarable.html.erb
@@ -5,14 +5,14 @@
     <nav class="trail">
       <dl>
         <dt class="section-number">Section <%= declarable.section_numeral %></dt>
-        <dd class="section-title tariff-fragments"><%= link_to declarable.section, section_path(declarable.section) %>
+        <dd class="section-title tariff-fragments"><%= link_to declarable.section, section_path(declarable.section, request.query_parameters.symbolize_keys) %>
           <dl class="tariff-fragments">
             <dt class="chapter-code" title="Chapter code"><%= declarable.chapter_short_code %></dt>
-            <dd><%= link_to declarable.chapter, chapter_path(declarable.chapter) %>
+            <dd><%= link_to declarable.chapter, chapter_path(declarable.chapter, request.query_parameters.symbolize_keys) %>
               <dl>
                 <dt class="heading-code" title="Heading code"><%= declarable.heading_display_short_code %></dt>
                 <% if declarable.show_commodity_tree? %>
-                  <dd><%= link_to declarable.heading.to_s.html_safe, heading_path(declarable.heading) %>
+                  <dd><%= link_to declarable.heading.to_s.html_safe, heading_path(declarable.heading, request.query_parameters.symbolize_keys) %>
                       <%= commodity_tree(declarable, declarable.ancestors) %>
                   </dd>
                 <% else %>

--- a/app/views/headings/_heading.html.erb
+++ b/app/views/headings/_heading.html.erb
@@ -6,7 +6,7 @@
 <dd class="subtitle-description">
 <% end %>
   <% if heading.leaf? %>
-    <%= link_to heading.formatted_description.html_safe, heading_path(heading) %>
+    <%= link_to heading.formatted_description.html_safe, heading_path(heading, request.query_parameters.symbolize_keys) %>
   <% else %>
   <dl class='chapter-headings'>
     <%= render heading.children %>

--- a/app/views/headings/show.html.erb
+++ b/app/views/headings/show.html.erb
@@ -10,10 +10,10 @@
     <div class="inner">
       <dl>
         <dt class="section-number">Section <%= @heading.section.numeral %></dt>
-        <dd class="section-title"><%= link_to @heading.section.title, section_path(@heading.section) %>
+        <dd class="section-title"><%= link_to @heading.section.title, section_path(@heading.section, request.query_parameters.symbolize_keys) %>
           <dl class="tariff-fragments">
             <dt class="chapter-code" title="Chapter code"><%= @heading.chapter_short_code %></dt>
-            <dd><%= link_to @heading.chapter, chapter_path(@heading.chapter) %>
+            <dd><%= link_to @heading.chapter, chapter_path(@heading.chapter, request.query_parameters.symbolize_keys) %>
               <dl>
                 <dt class="heading-code" title="Heading code"><%= @heading.display_short_code %></dt>
                 <dd>

--- a/app/views/sections/_section.html.erb
+++ b/app/views/sections/_section.html.erb
@@ -4,4 +4,7 @@
   </span>
   <%= section.chapters_title %>
 </dt>
-<dd class='title'><%= link_to section, section_path(section), title: "Section #{section.position}" %></dd>
+
+<dd class='title'>
+  <%= link_to section, section_path(section, request.query_parameters.symbolize_keys), title: "Section #{section.position}" %>
+</dd>

--- a/app/views/sections/show.html.erb
+++ b/app/views/sections/show.html.erb
@@ -8,7 +8,7 @@
     <dl>
       <dt class="section-number">Section <%= @section.numeral %></dt>
       <dd class="section-title">
-        <h1><%= link_to @section, sections_path %></h1>
+        <h1><%= link_to @section, sections_path(request.query_parameters.symbolize_keys) %></h1>
         <!--<p class="chapters-intro">Microcopy about what chapters are goes here.</p>-->
         <dl class="tariff-fragments chapters">
         <%= render @chapters %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -34,8 +34,8 @@
   </fieldset>
 
   <fieldset class='relevant-links'>
-    <a href="<%= sections_path %>">View all sections</a>
-    <a href="<%= a_z_index_path(letter: 'a') %>">A-Z Index</a>
+    <%= link_to "View all sections", sections_path(request.query_parameters.symbolize_keys) %>
+    <%= link_to "A-Z Index", a_z_index_path(letter: "a") %>
   </fieldset>
 
   <fieldset class='country-picker help-notice'>


### PR DESCRIPTION
#### What this PR does:

Persist the date and country in the links.

![urls](https://cloud.githubusercontent.com/assets/1143421/17417244/f5f85ef0-5a57-11e6-99de-b53c5a8d8a8d.gif)

#### Notes

We prefer to update the links individually because only of them are
require to persist this query string, so no need to override  the method `default_url_options` to apply the query string to all links.