### PR TITLE
Moved VAT info to just below the goods nomenclature number

### DIFF
--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -27,15 +27,15 @@
           <div class="import box">
             <h2 class="heading-medium">Import</h2>
             <p>The commodity code for importing is <strong><%= declarable.code %></strong>.</p>
+            <% declarable.import_measures.vat.national.each do |measure| %>
+              <p>Goods are subject to <%= measure.measure_type.description %>.</p>
+            <% end %>
             <% if declarable.basic_duty_rate.present? %>
-              <p>Importing from outside the EU is subject to a third country duty of <strong><%= declarable.basic_duty_rate.html_safe %></strong> unless subject to other measures. <!-- <a href="#">What does this mean?</a></p> -->
+              <p>Importing from outside the EU is subject to a third country duty of <strong><%= declarable.basic_duty_rate.html_safe %></strong> unless subject to other measures.</p>
             <% else %>
               <p>Importing from outside the EU is subject to <strong>variable</strong> third country duty.</p>
             <% end %>
             <p> Import measures and restrictions for specific countries can be found under the <a href="#import">import</a> tab.</p>
-            <% declarable.import_measures.vat.national.each do |measure| %>
-              <p>Goods are subject to <%= measure.measure_type.description %>.</p>
-            <% end %>
           </div>
         </div>
 


### PR DESCRIPTION
(on commodity overview tab)