### PR TITLE
Commodity overview warning banner

### DIFF
--- a/app/views/declarables/_declarable.html.erb
+++ b/app/views/declarables/_declarable.html.erb
@@ -1,6 +1,9 @@
 <% content_for :title, "#{declarable.description_plain} - Trade Tariff - GOV.UK" %>
 
 <article class="tariff commodity">
+  <div class="panel panel-border-wide">
+    <p>Check the chapter notes to make sure this code is suitable for your product.</p>
+  </div>
   <%= render 'shared/tariff_breadcrumbs', declarable: declarable %>
   <%= render 'measures/measures', declarable: declarable %>
 </article>

--- a/app/views/headings/show.html.erb
+++ b/app/views/headings/show.html.erb
@@ -3,14 +3,12 @@
   <link rel='alternate' type='application/json' href='<%= heading_url(@heading, format: :json) %>' title='Heading information page in JSON format' />
 <% end %>
 
-  <h2 class="heading-medium">Choose the commodity code that best matches your goods</h2>
-  <p>If your item is not listed by name, it may be shown under what it's used for, what it's made from or 'other.'</p>
-
 <% if @heading.declarable? %>
   <%= render 'declarables/declarable', declarable: @heading %>
 <% else %>
+  <h2 class="heading-medium">Choose the commodity code that best matches your goods</h2>
+  <p>If your item is not listed by name, it may be shown under what it's used for, what it's made from or 'other.'</p>
   <%= render 'shared/tariff_breadcrumbs', heading: @heading %>
-
   <article class="tariff">
     <div class="tree-key">
       <div class="chapter-code">


### PR DESCRIPTION
Added banner and made a fix that stopped the incorrect text displaying for heading-level declarables.

![image](https://cloud.githubusercontent.com/assets/1254508/18706497/2926a860-7fea-11e6-8082-d30a0e4cbad8.png)
