### PR TITLE
Call the `FS.clearUserCookie` function from the FullStory plugin at t…

### DIFF
--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -37,10 +37,6 @@
       d=n.domain;while(1){n.cookie='fs_uid=;domain='+d+
       ';path=/;expires='+new Date(0);i=d.indexOf('.');if(i<0)break;d=d.slice(i+1)}}};
     })(window,document,window['_fs_namespace'],'script','user');
-
-    $(window).unload(function() {
-      FS.clearUserCookie();
-    });
   </script>
 <% end %>
 
@@ -106,5 +102,10 @@
 <% end %>
 
 <% content_for :body_end do %>
-  <%= javascript_include_tag 'application' %>
+  <%= javascript_include_tag "application" %>
+  <script type="text/javascript" charset="utf-8">
+    $(window).unload(function() {
+      FS.clearUserCookie();
+    });
+  </script>
 <% end %>


### PR DESCRIPTION
Call the `FS.clearUserCookie` function from the FullStory plugin at the bottom

Since the code must be on the `head`, no other js libraries are loaded,
so calling the $ here will result in an error, move this code to clear
the cookies at the bottom of the page.