### PR TITLE
[WIP] Erga omnes measures

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -6,6 +6,8 @@ class Measure
   attr_accessor :id, :origin, :effective_start_date, :effective_end_date,
                 :import, :vat, :excise
 
+  DEFAULT_GEOGRAPHICAL_AREA_ID = "1011" #ERGA OMNES
+
   has_one :geographical_area
   has_one :legal_act
   has_one :measure_type
@@ -19,7 +21,9 @@ class Measure
 
   def relevant_for_country?(country_code)
     return false if excluded_countries.map(&:geographical_area_id).include?(country_code)
-    return true if country_code.blank? || national? || geographical_area.id == country_code
+    return true if geographical_area.id == DEFAULT_GEOGRAPHICAL_AREA_ID && national?
+    return true if country_code.blank? || geographical_area.id == country_code
+
     geographical_area.children_geographical_areas.map(&:id).include?(country_code)
   end
 

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -18,16 +18,9 @@ class Measure
   has_many :footnotes
 
   def relevant_for_country?(country_code)
-    return true if country_code.blank?
-    ( ( geographical_area.id == country_code ||
-        geographical_area.children_geographical_areas.map(&:id).include?(country_code)
-      ) && !excludes_geographical_area?(country_code)
-    ) ||
-    ( national? && !excludes_geographical_area?(country_code) )
-  end
-
-  def excludes_geographical_area?(country_code)
-    excluded_countries.map(&:geographical_area_id).include?(country_code)
+    return false if excluded_countries.map(&:geographical_area_id).include?(country_code)
+    return true if country_code.blank? || national? || geographical_area.id == country_code
+    geographical_area.children_geographical_areas.map(&:id).include?(country_code)
   end
 
   def excluded_country_list

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -10,9 +10,9 @@ describe Measure do
       ).to eq true
     end
 
-    it 'returns true if a national measure regardless of the geographical area' do
-      measure = Measure.new(attributes_for(:measure, :national, geographical_area: {id: 'lt',
-                                                                         description: 'Lithuania'}))
+    it 'returns true if a national measure and geographical area code is equal to 1011' do
+      measure = Measure.new(attributes_for(:measure, :national, geographical_area: {id: '1011',
+                                                                         description: 'ERGA OMNES'}))
       expect(
         measure.relevant_for_country?('br')
       ).to eq true


### PR DESCRIPTION
This PR changes the filter used to show the measures, before of this change any national measure was displayed, now we check if the geographical code id is the default one for chief measures, `Erga Omnes` too.

