### PR TITLE
hide link’s href for EEC print commodity

### DIFF
--- a/app/assets/stylesheets/tariff-print.scss
+++ b/app/assets/stylesheets/tariff-print.scss
@@ -31,3 +31,6 @@ article dd ul a {
 	left:auto;
 	display:block;
 }
+a.print-link-without-description:after {
+	content: "";
+}

--- a/app/views/measures/_measure.html.erb
+++ b/app/views/measures/_measure.html.erb
@@ -42,7 +42,7 @@
 
   <td class="numerical">
     <% if measure.legal_act.present? %>
-      <%= link_to measure.legal_act.generating_regulation_code, measure.legal_act.url, target: '_blank', rel: 'external' %>
+      <%= link_to measure.legal_act.generating_regulation_code, measure.legal_act.url, target: '_blank', rel: 'external', class: 'print-link-without-description' %>
     <% end %>
   </td>
 


### PR DESCRIPTION
govuk_template’s default is to show link hrefs in print versions. overwriting it for EEC in commodity table
https://github.com/alphagov/govuk_template/blob/v0.18.3/source/assets/stylesheets/_core-print.scss#L23