### PR TITLE
Tweaking print styles

### DIFF
--- a/app/assets/stylesheets/tariff-print.scss
+++ b/app/assets/stylesheets/tariff-print.scss
@@ -34,3 +34,53 @@ article dd ul a {
 a.print-link-without-description:after {
 	content: "";
 }
+
+.hidden-print {
+  display: none !important;
+}
+
+.visible-print {
+  display: initial !important;
+  visibility: visible !important;
+}
+
+a[href^="/"]:after,
+a[href^="http://"]:after,
+a[href^="https://"]:after {
+  display: none;
+}
+
+.back-to-previous {
+  display: none;
+}
+
+.js-header-toggle.menu {
+  display: none;
+}
+
+
+.header-proposition {
+  display: none;
+}
+
+
+#proposition-name {
+  position: relative;
+  top: -0.2em;
+  font-size: 1.7em;
+  padding-left: 0.5em;
+  margin-left: 0.5em;
+  border-left: 2px solid #000;
+}
+
+#proposition-links {
+  display: none;
+}
+
+.js-tabs.nav-tabs {
+  display: none;
+}
+
+.popup.hidden {
+  display: none !important;
+}

--- a/app/assets/stylesheets/tariff.scss
+++ b/app/assets/stylesheets/tariff.scss
@@ -100,3 +100,8 @@ section, article {
     padding: 0.60em 2em 0.45em 0.67em;
   }
 }
+
+.visible-print {
+  display: none;
+  visibility: hidden;
+}

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,7 +1,7 @@
 <% if controller_name == 'commodities' && action_name == 'show' || controller_name == 'headings' && action_name == 'show' && @heading.declarable? %>
   <header>
     <a class="back-to-previous" href="<%= @back_path %>">Back <span class="visuallyhidden"> to the list of commodities</span></a>
-    <h1 class="heading-large">Commodity information</h1>
+    <h1 class="heading-large">Commodity information <span class="visible-print">for <%= (@commodity || @heading).code %></span></h1>
     <%= form_tag perform_search_path, method: :get, class: "tariff-search #{@section_css}", id: "new_search" do |f| %>
       <div class="grid-row">
         <div class="column-full">


### PR DESCRIPTION
This PR tweaks some of the styles applied when printing the pages. A lot of elements that were being printed didn't make sense, like the menu, back links and some hidden elements.

- On the heading, only leaving the Gov UK logo
- Removing back to previous page link
- On the commodities title, adding "for ########" to give context when
printing
- Popup for the 'Order no.' that was mixed inside table is hidden on
print, leaving only the one at the end of the page
- Removing URLs of links inside parenthesis

Here is a gif demonstrating the print preview in normal view, then when clicking the conditions popup (which only appears at the end), and then clicking on the Order No. popup, which now only appears at the end.

![ro7bki0oqw](https://user-images.githubusercontent.com/758001/26928150-586ff384-4c2b-11e7-8f2c-062f54584899.gif)
