### PR TITLE
Making commodity code visible in header not only in print

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,7 +1,7 @@
 <% if controller_name == 'commodities' && action_name == 'show' || controller_name == 'headings' && action_name == 'show' && @heading.declarable? %>
   <header>
     <a class="back-to-previous" href="<%= @back_path %>">Back <span class="visuallyhidden"> to the list of commodities</span></a>
-    <h1 class="heading-large">Commodity information <span class="visible-print">for <%= (@commodity || @heading).code %></span></h1>
+    <h1 class="heading-large">Commodity information for <%= (@commodity || @heading).code %></h1>
     <%= form_tag perform_search_path, method: :get, class: "tariff-search #{@section_css}", id: "new_search" do |f| %>
       <div class="grid-row">
         <div class="column-full">


### PR DESCRIPTION
In previous PR, we added context in the commodity header by adding the code.
This PR simply removes the constraint to only show when printing, making it visible all the time, as shown in picture below.

![screen shot 2017-06-08 at 16 43 49](https://user-images.githubusercontent.com/758001/26947609-b8068ebe-4c69-11e7-9c9a-abb44ed3c977.png)
