### PR TITLE
prevent  calling `xmlschema` for nil object

### DIFF
--- a/app/views/changes/index.atom.builder
+++ b/app/views/changes/index.atom.builder
@@ -12,7 +12,7 @@ atom_feed do |feed|
     ) do |entry|
       entry.title(change.title)
       entry.content(change.content)
-      entry.updated(change.operation_date.xmlschema)
+      entry.updated(change.operation_date.try(:xmlschema))
 
       entry.author do |author|
         author.name("UK government")


### PR DESCRIPTION
Sentry error: https://sentry.io/bit-zesty-client-apps/frontend/issues/390174157/