### PR TITLE
[COMODITY CODES] Display codes for headings

### DIFF
--- a/app/assets/stylesheets/_commodity-tree.scss
+++ b/app/assets/stylesheets/_commodity-tree.scss
@@ -215,6 +215,10 @@ article.tariff {
       background-repeat: no-repeat;
       cursor:pointer;
       position:relative; /* to give z-index */
+
+      &.without_right_margin {
+        margin: 0 !important;
+      }
     }
 
    .description:hover,
@@ -230,6 +234,18 @@ article.tariff {
 
     .open {
       background-position:0 -386px;
+    }
+
+    .sub_heading_commodity_code_block {
+      width: 150px;
+
+      .chapter-code, .heading-code, .commodity-code {
+        float: left;
+      }
+
+      .code-text {
+        text-align: center;
+      }
     }
   }
 

--- a/app/assets/stylesheets/_commodity-tree.scss
+++ b/app/assets/stylesheets/_commodity-tree.scss
@@ -237,6 +237,7 @@ article.tariff {
     }
 
     .sub_heading_commodity_code_block {
+      color: #696969;
       width: 150px;
 
       .chapter-code, .heading-code, .commodity-code {

--- a/app/assets/stylesheets/tariff.scss
+++ b/app/assets/stylesheets/tariff.scss
@@ -106,3 +106,11 @@ section, article {
   display: none;
   visibility: hidden;
 }
+
+.pull-left {
+  float: left;
+}
+
+.pull-right {
+  float: right;
+}

--- a/app/helpers/commodities_helper.rb
+++ b/app/helpers/commodities_helper.rb
@@ -30,12 +30,7 @@ module CommoditiesHelper
 
   def format_full_code(commodity)
     code = commodity.code.to_s
-    "<div class='chapter-code'>
-      <div class='code-text'>#{code[0..1]}</div>
-    </div>
-    <div class='heading-code'>
-      <div class='code-text'>#{code[2..3]}</div>
-    </div>
+    "#{chapter_and_heading_codes(code)}
     <div class='commodity-code'>
       <div class='code-text'>#{code[4..5]}</div>
       <div class='code-text'>#{code[6..7]}</div>
@@ -43,7 +38,41 @@ module CommoditiesHelper
     </div>".html_safe
   end
 
+  def format_commodity_code_based_on_level(commodity)
+    code = commodity.code.to_s
+
+    if commodity.number_indents > 1
+      code = if code[6..9] == "0000"
+        code[0..5]
+      elsif code[8..9] == "00"
+        code[0..7]
+      else
+        code
+      end
+
+      "#{chapter_and_heading_codes(code)}
+      <div class='commodity-code'>
+        <div class='code-text pull-left'>#{code[4..5]}</div>
+        #{code_text(code[6..7])}
+        #{code_text(code[8..9])}
+      </div>".html_safe
+    end
+  end
+
   private
+
+  def chapter_and_heading_codes(code)
+    "<div class='chapter-code'>
+      <div class='code-text'>#{code[0..1]}</div>
+    </div>
+    <div class='heading-code'>
+      <div class='code-text'>#{code[2..3]}</div>
+    </div>"
+  end
+
+  def code_text(code)
+    "<div class='code-text pull-left'>#{code}</div>" if code.present?
+  end
 
   def tree_node(main_commodity, commodities, depth)
     deeper_node = commodities.select{ |c| c.number_indents == depth + 1 }.first

--- a/app/views/commodities/_commodity.html.erb
+++ b/app/views/commodities/_commodity.html.erb
@@ -1,14 +1,20 @@
 <% if commodity.has_children? %>
   <li class="has_children <%= commodity_level(commodity)%><%= leaf_position(commodity) %>">
-    <span class="description open" id="commodity-<%= commodity.short_code %>"><%= commodity.to_s.html_safe %></span>
+    <span class="description open without_right_margin" id="commodity-<%= commodity.short_code %>"><%= commodity.to_s.html_safe %></span>
+
+    <div class='sub_heading_commodity_code_block pull-right'>
+      <%= format_commodity_code_based_on_level(commodity) %>
+    </div>
+
     <ul><%= render commodity.children %></ul>
   </li>
 <% else %>
   <li class="<%= commodity_level(commodity)%><%= leaf_position(commodity) %>">
     <%= link_to commodity_path(commodity, request.query_parameters.symbolize_keys), title: "View complete information for this commodity" do %>
       <div class="description open" id="commodity-<%= commodity.short_code %>"><%= commodity.to_s.html_safe %></div>
+
       <div class="identifier" aria-describedby="commodity-<%= commodity.short_code %>">
-        <%= format_full_code(commodity) %>
+        <%= format_commodity_code_based_on_level(commodity) %>
       </div>
     <% end %>
   </li>


### PR DESCRIPTION
[TRELLO CARD](https://trello.com/c/rrdFsrwQ/2027-tariff17-display-codes-for-headings)

```
Like the EU does, display code 6 places depending on the level.

level 1 - do not display
level 2+ - display 6 numbers (unless declarable then show the full code)

This can be useful for exporters who do not need the full code
```

We need to  heading details page (eg: https://www.trade-tariff.service.gov.uk/trade-tariff/headings/0306) to look like on attached screen:

![example](https://user-images.githubusercontent.com/358508/34721388-9486826c-f553-11e7-97d1-3015befb638c.png)

How https://www.trade-tariff.service.gov.uk/trade-tariff/headings/0306 looks now in this PR code:

![heading_0306](https://user-images.githubusercontent.com/358508/34721606-64fa26c4-f554-11e7-95d3-211d8f9a8029.png)
