### PR TITLE
[FOR NATIONAL MEASURES] do not show 'Council Regulation (EEC)' link

### DIFF
--- a/app/views/measures/_measure.html.erb
+++ b/app/views/measures/_measure.html.erb
@@ -42,7 +42,7 @@
   <td><%= measure.excluded_country_list %></td>
 
   <td class="numerical">
-    <% if measure.legal_act.present? %>
+    <% if !measure.national? && measure.legal_act.present? %>
       <%= link_to measure.legal_act.generating_regulation_code, "##{measure.destination}-#{measure.legal_act.url_safe_code}-regulations", class: 'reference', 'data-popup-ref' => "#{measure.destination}-#{measure.legal_act.url_safe_code}-regulations" %>
     <% end %>
   </td>

--- a/app/views/measures/_measure_references.html.erb
+++ b/app/views/measures/_measure_references.html.erb
@@ -22,39 +22,39 @@
 </div>
 <% end %>
 
-<% if measure.legal_act.present? %>
-<div class='regulations' id='<%= measure.legal_act.url_safe_code %>' data-popup='<%= measure.destination %>-<%= measure.legal_act.url_safe_code %>-regulations'>
-  <article>
-    <table class="small-table">
-      <caption>
-        <h2>Council Regulation (EEC)</h2>
-      </caption>
-      <thead>
-        <tr>
-          <th>Regulation No.</th>
-          <th>Start date</th>
-          <th>End date</th>
-          <th>Publication date</th>
-          <th>Journal No.</th>
-          <th>Journal page</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>
-            <%= link_to measure.legal_act.generating_regulation_code, measure.legal_act.url, target: '_blank', rel: 'external', class: 'print-link-without-description' %>
-          </td>
-          <td><%= measure.legal_act.validity_start_date %></td>
-          <td><%= measure.legal_act.validity_end_date %></td>
-          <td><%= measure.legal_act.published_date %></td>
-          <td><%= measure.legal_act.officialjournal_number %></td>
-          <td><%= measure.legal_act.officialjournal_page %></td>
-        </tr>
-      </tbody>
-    </table>
-  </article>
-</div>
+<% if !measure.national? && measure.legal_act.present? %>
+  <div class='regulations' id='<%= measure.legal_act.url_safe_code %>' data-popup='<%= measure.destination %>-<%= measure.legal_act.url_safe_code %>-regulations'>
+    <article>
+      <table class="small-table">
+        <caption>
+          <h2>Council Regulation (EEC)</h2>
+        </caption>
+        <thead>
+          <tr>
+            <th>Regulation No.</th>
+            <th>Start date</th>
+            <th>End date</th>
+            <th>Publication date</th>
+            <th>Journal No.</th>
+            <th>Journal page</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <%= link_to measure.legal_act.generating_regulation_code, measure.legal_act.url, target: '_blank', rel: 'external', class: 'print-link-without-description' %>
+            </td>
+            <td><%= measure.legal_act.validity_start_date %></td>
+            <td><%= measure.legal_act.validity_end_date %></td>
+            <td><%= measure.legal_act.published_date %></td>
+            <td><%= measure.legal_act.officialjournal_number %></td>
+            <td><%= measure.legal_act.officialjournal_page %></td>
+          </tr>
+        </tbody>
+      </table>
+    </article>
+  </div>
 <% end %>
 
 <% measure.footnotes.each do |footnote| %>


### PR DESCRIPTION
It's a placeholder code from CHIEF, not a real valid code, so do not display anything on the frontend for it.
If national do not show the 'Council Regulation (EEC)' link.

[TRELLO CARD](https://trello.com/c/2qNKK1NT/466-tariff17-hide-i9999-yy-from-the-regulations-on-the-tariff-frontend)