### PR TITLE
[HEADING] rolling back of 'displaying of codes for sub headings'

### DIFF
--- a/app/views/commodities/_commodity.html.erb
+++ b/app/views/commodities/_commodity.html.erb
@@ -2,9 +2,9 @@
   <li class="has_children <%= commodity_level(commodity)%><%= leaf_position(commodity) %>">
     <span class="description open without_right_margin" id="commodity-<%= commodity.short_code %>"><%= commodity.to_s.html_safe %></span>
 
-    <div class='sub_heading_commodity_code_block pull-right'>
-      <%= format_commodity_code_based_on_level(commodity) %>
-    </div>
+<!--     <div class='sub_heading_commodity_code_block pull-right'>
+      <%#= format_commodity_code_based_on_level(commodity) %>
+    </div> -->
 
     <ul><%= render commodity.children %></ul>
   </li>
@@ -14,7 +14,8 @@
       <div class="description open" id="commodity-<%= commodity.short_code %>"><%= commodity.to_s.html_safe %></div>
 
       <div class="identifier" aria-describedby="commodity-<%= commodity.short_code %>">
-        <%= format_commodity_code_based_on_level(commodity) %>
+        <%= format_full_code(commodity) %>
+        <%#= format_commodity_code_based_on_level(commodity) %>
       </div>
     <% end %>
   </li>


### PR DESCRIPTION
In a [PR](https://github.com/bitzesty/trade-tariff-frontend/pull/161)
we implemented displaying of codes for sub headings in a Heading details page.

But as we see now there are more cases which we need to handle in order
to display codes for sub headings properly.

So that we are going to comment in this stuff for now and return previously used
displaying of codes just for declarable commodities.

Once we finish corrects for codes for sub headings we will enable this stuff again.

[TRELLO CARD](https://trello.com/c/ND5Qd5Mc/452-tariff17-display-codes-for-headings)