### PR TITLE
Adding footnote partial for non declarable too

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -12,7 +12,7 @@ ignore:
     - '* > nokogiri@1.8.1':
         reason: None given
         expires: '2018-01-05T09:50:06.541Z'
-    - '* > nokogiri@1.8.1':
+    - '* > nokogiri@1.8.2':
         reason: None given
         expires: '2018-03-14T13:00:14.090Z'
   SNYK-RUBY-ACTIONCABLE-20338:

--- a/.snyk
+++ b/.snyk
@@ -14,7 +14,7 @@ ignore:
         expires: '2018-01-05T09:50:06.541Z'
     - '* > nokogiri@1.8.1':
         reason: None given
-        expires: '2018-02-08T13:00:14.090Z'
+        expires: '2018-03-14T13:00:14.090Z'
   SNYK-RUBY-ACTIONCABLE-20338:
     - '* > rails@5.1.3':
         reason: None given

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,7 +147,7 @@ GEM
     multipart-post (2.0.0)
     newrelic_rpm (4.6.0.338)
     nio4r (2.1.0)
-    nokogiri (1.8.1)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     poltergeist (1.14.0)
       capybara (~> 2.1)

--- a/app/views/headings/_footnote.html.erb
+++ b/app/views/headings/_footnote.html.erb
@@ -8,7 +8,7 @@
         </tr>
         </thead>
         <tbody>
-        <%= render footnote %>
+          <%= render footnote %>
         </tbody>
     </table>
 <% end %>

--- a/app/views/headings/_footnote.html.erb
+++ b/app/views/headings/_footnote.html.erb
@@ -1,0 +1,14 @@
+<% if footnote&.code&.present? %>
+    <table class="small-table">
+        <caption class="heading-medium">Commodity footnotes</caption>
+        <thead>
+        <tr>
+            <th scope="col">Code</th>
+            <th scope="col">Description</th>
+        </tr>
+        </thead>
+        <tbody>
+        <%= render footnote %>
+        </tbody>
+    </table>
+<% end %>

--- a/app/views/headings/show.html.erb
+++ b/app/views/headings/show.html.erb
@@ -25,5 +25,6 @@
         <%= render @commodities.root_commodities %>
       </ul>
     </div>
+    <%= render 'footnote', footnote: @heading.footnote %>
   </article>
 <% end %>

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -65,20 +65,7 @@
           </div>
         </div>
       </div>
-    <% if declarable.footnote.code.present? %>
-      <table class="small-table">
-        <caption class="heading-medium">Commodity footnotes</caption>
-        <thead>
-          <tr>
-            <th scope="col">Code</th>
-            <th scope="col">Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <%= render declarable.footnote %>
-        </tbody>
-      </table>
-    <% end %>
+    <%= render 'footnote', footnote: declarable.footnote %>
     <% if declarable.meursing_code? %>
       <h2 class="heading-medium">This commodity has a meursing code</h2>
       <p>Use the <%= link_to "Look up Meursing code", "https://www.gov.uk/additional-commodity-code", rel: "external", target: "_blank", title: "Opens in a new window" %> tool to find the additional code required for importing and exporting. To calculate the duty rate, enter the meursing code (without the 7 at the start) into the <%= link_to "meursing calculator", declarable.meursing_tool_link_for(@search.date.to_taric_date), rel: "external", target: "_blank", title: "Opens in a new window" %>.</p>

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -65,7 +65,7 @@
           </div>
         </div>
       </div>
-    <%= render 'footnote', footnote: declarable.footnote %>
+    <%= render 'headings/footnote', footnote: declarable.footnote %>
     <% if declarable.meursing_code? %>
       <h2 class="heading-medium">This commodity has a meursing code</h2>
       <p>Use the <%= link_to "Look up Meursing code", "https://www.gov.uk/additional-commodity-code", rel: "external", target: "_blank", title: "Opens in a new window" %> tool to find the additional code required for importing and exporting. To calculate the duty rate, enter the meursing code (without the 7 at the start) into the <%= link_to "meursing calculator", declarable.meursing_tool_link_for(@search.date.to_taric_date), rel: "external", target: "_blank", title: "Opens in a new window" %>.</p>


### PR DESCRIPTION
*ORIGINAL ISSUE DESCRIPTION:*

Issue was that for some cases the footnote wasn't being shown, even though heading had a relation to the footnote. One example where footnote was being displayed correctly :

http://localhost:3000/trade-tariff/headings/4903

And another where it was not implemented correctly is this one :

http://localhost:3000/trade-tariff/headings/6402

*WHAT'S WE DONE IN THIS PR:*

Added footnote and some other details to the payload (in the back-end), and when there is a footnote present rendering it on the page, regardless if it's declarable or not.

[TRELLO STORY](https://trello.com/c/MR5lJoaS/475-tariff17-investigate-commodity-footnote-not-appearing)