### PR TITLE
[FRONTEND] should NOT display tariff date when for failed import

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,13 +42,7 @@ class ApplicationController < ActionController::Base
   private
 
   def set_last_updated
-    @tariff_last_updated ||= Rails.cache.fetch(
-      "tariff_last_updated",
-      expires_in: 1.hour
-    ) do
-      last = TariffUpdate.all.first
-      last ? last.updated_at : nil
-    end
+    @tariff_last_updated ||= TariffUpdate.latest_applied_import_date
   end
 
   def search_invoked?

--- a/app/controllers/goods_nomenclatures_controller.rb
+++ b/app/controllers/goods_nomenclatures_controller.rb
@@ -8,7 +8,7 @@ class GoodsNomenclaturesController < ApplicationController
   end
 
   def find_relevant_goods_code_or_fallback
-    @search = Search.new(t: goods_code_id, as_of: Date.current)
+    @search = Search.new(t: goods_code_id, as_of: @tariff_last_updated)
     results = @search.perform
 
     if results.exact_match?

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -43,7 +43,7 @@ class Search
   end
 
   def filtered_by_date?
-    date.date != Date.current
+    date.date != TariffUpdate.latest_applied_import_date
   end
 
   def filtered_by_country?

--- a/app/models/tariff_date.rb
+++ b/app/models/tariff_date.rb
@@ -14,7 +14,7 @@ class TariffDate
     new(if valid_date_param?(date_param)
       date_param.values_at(*DATE_KEYS).join("-")
     else
-      Date.current
+      TariffUpdate.latest_applied_import_date
     end)
   end
 
@@ -32,7 +32,7 @@ class TariffDate
   end
 
   def date
-    @date.presence || Date.current
+    @date.presence || TariffUpdate.latest_applied_import_date
   end
 
   def persisted?


### PR DESCRIPTION
*WHAT IS THE ISSUE:*

We are displaying tariff date at below main search bar, on commodity and heading detailed pages.
Currently, it always displaying current date, instead of date of latest successful tariff import.

*WHAT DOES THIS PR?*

We introduced `TariffUpdate.latest_applied_import_date` class method, which fetches date
of latest successful import.
This value would be cached and expired every 1 hour.

So, that users of tariff application would see proper date of tariffs.

[TRELLO STORY](https://trello.com/c/OD80LnPa/2111-tariff17-the-frontend-should-not-display-dates-for-when-we-have-failed-updates)