### PR TITLE
Moving chapter notes away from the tab

### DIFF
--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -7,6 +7,8 @@
 
 <%= render 'shared/tariff_breadcrumbs', chapter: @chapter %>
 
+<%= render 'shared/callout' %>
+
 <section class="headings">
   <table class="section-browser">
     <tbody>

--- a/app/views/headings/show.html.erb
+++ b/app/views/headings/show.html.erb
@@ -9,6 +9,7 @@
   <h2 class="heading-small">Choose the commodity code below that best matches your goods to see more information</h2>
   <p>If your item is not listed by name, it may be shown under what it's used for, what it's made from or 'other'.</p>
   <%= render 'shared/tariff_breadcrumbs', heading: @heading %>
+  <%= render 'shared/callout' %>
   <article class="tariff">
     <div class="tree-key">
       <div class="chapter-code">

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -9,9 +9,6 @@
     <li>
       <a href="#export">Export</a>
     </li>
-    <li>
-      <a href="#notes">Chapter notes</a>
-    </li>
   </ul>
 </div>
 
@@ -70,6 +67,9 @@
       <h2 class="heading-medium">This commodity has a meursing code</h2>
       <p>Use the <%= link_to "Look up Meursing code", "https://www.gov.uk/additional-commodity-code", rel: "external", target: "_blank", title: "Opens in a new window" %> tool to find the additional code required for importing and exporting. To calculate the duty rate, enter the meursing code (without the 7 at the start) into the <%= link_to "meursing calculator", declarable.meursing_tool_link_for(@search.date.to_taric_date), rel: "external", target: "_blank", title: "Opens in a new window" %>.</p>
     <% end %>
+    <!-- Chapter notes content -->
+    <h2 class="heading-medium">Chapter notes</h2>
+    <%= render 'shared/notes', section_note: declarable.section.section_note, chapter_note: declarable.chapter.chapter_note %>
     <h2 class="heading-medium">Binding tariff information</h2>
     <p>You can search the EU EBTI-database for existing <%= link_to "Binding Tariff Information", declarable.bti_url, rel: "external", target: "_blank", title: "Opens in a new window" %> for commodity code <strong><%= declarable.code %></strong>.</p>
     </div>
@@ -148,13 +148,6 @@
     <% end %>
 
   </article><!-- end .tab-pane -->
-
-  <!-- Chapter notes tab -->
-  <article class="js-tab-pane tab-pane" id="notes" data-id="<%= declarable.to_param %>" data-class="<%=declarable.class.name.downcase.pluralize %>">
-    <h2 class="heading-medium">Chapter notes</h2>
-    <%= render 'shared/notes', section_note: declarable.section.section_note, chapter_note: declarable.chapter.chapter_note %>
-  </article><!-- end .tab-pane -->
-
   <!-- Footnote popups -->
   <div id="import-measure-references">
     <%= render partial: 'measures/measure_references', collection: declarable.import_measures.for_country(@search.country), as: 'measure' %>

--- a/app/views/shared/_callout.html.erb
+++ b/app/views/shared/_callout.html.erb
@@ -1,0 +1,5 @@
+<div class="panel panel-border-wide">
+    <p>
+        There are important <%= link_to "chapter notes", "#chapter-notes" %> shown further down this page.
+    </p>
+</div>


### PR DESCRIPTION
*ORIGINAL ISSUE DESCRIPTION:*

Move section/chapter notes to other section of the page away from tabs

*WHAT'S WE DONE IN THIS PR:*

- chapter notes added above binding tarrif in commodity page
- Calout added in chapter page
- Callout saved to partial for the pages

[TRELLO STORY](https://trello.com/c/YDtpanQs/477-tariff17-chapter-and-section-notes-need-to-be-more-clearly-highlighted)

Here are some screenshot per @matthewford request.

**Commodity Page:**

<img width="663" alt="screen shot 2018-02-22 at 7 37 05 am" src="https://user-images.githubusercontent.com/36192669/36538983-414ceed4-17a3-11e8-8eba-8dc40672428d.png">

**Heading page (declarable) :**

<img width="686" alt="screen shot 2018-02-22 at 7 38 50 am" src="https://user-images.githubusercontent.com/36192669/36539054-79e33708-17a3-11e8-8874-486d8806dfe2.png">

**Heading page (non-declarable) :**

<img width="660" alt="screen shot 2018-02-22 at 7 40 11 am" src="https://user-images.githubusercontent.com/36192669/36539094-9d66f84a-17a3-11e8-8639-7aef28b9b205.png">

**Chapter page**

<img width="666" alt="screen shot 2018-02-22 at 7 43 40 am" src="https://user-images.githubusercontent.com/36192669/36539246-2131193a-17a4-11e8-9444-68e8b58b472f.png">




