### PR TITLE
Changes measures table v2

### DIFF
--- a/app/assets/javascripts/commodities.js.erb
+++ b/app/assets/javascripts/commodities.js.erb
@@ -661,6 +661,43 @@
           }
         }
       },
+      measuresTable: {
+        initialize: function() {
+          this.$tables = $("table.measures");
+
+          if (this.$tables.length <= 0) {
+            return;
+          }
+
+          this.bindEvents();
+          this.enforceHeights()
+        },
+        bindEvents: function() {
+          var self = this;
+
+          $(window).on("resize", function() {
+            self.enforceHeights();
+          });
+        },
+        enforceHeights: function() {
+          var windowWidth = $(window).width();
+
+          this.$tables.each(function() {
+            var table = $(this);
+
+            table.find("dt.has_children").each(function() {
+              var dt = $(this);
+              var secondColumn = dt.closest("td").next();
+
+              if (windowWidth > 839) {
+                dt.css("height", secondColumn.outerHeight() + "px");
+              } else {
+                dt.css("height", "auto");
+              }
+            });
+          });
+        }
+      },
       /**
         @name initialize
         @function
@@ -682,6 +719,7 @@
           this.searchHighlight.initialize();
           this.countryPicker.initialize();
           this.breadcrumbs.initialize();
+          this.measuresTable.initialize();
       }
   };
 

--- a/app/assets/stylesheets/_tables.scss
+++ b/app/assets/stylesheets/_tables.scss
@@ -58,6 +58,13 @@ table.small-table {
     display: none;
   }
   &.measures {
+    span.table-line {
+      display: block;
+      & ~ .table-line {
+        margin-top: 0.5em;
+      }
+    }
+
     @media (max-width: $small-table-breakpoint - 1) {
       caption, thead, tbody, th, td, tr {
         display: block;
@@ -89,6 +96,7 @@ table.small-table {
           white-space: nowrap;
         }
       }
+
       td:nth-of-type(1):before { content: 'Country'; }
       td:nth-of-type(2):before { content: 'Measure'; }
       td:nth-of-type(3):before { content: 'Value'; }
@@ -100,8 +108,8 @@ table.small-table {
     }
     @media (min-width: $small-table-breakpoint) {
       td:nth-of-type(1) { width: 18%; }
-      td:nth-of-type(2) { width: 19% }
-      td:nth-of-type(3) { width: 13% }
+      td:nth-of-type(2) { width: 23% }
+      td:nth-of-type(3) { width: 7.4% }
       td:nth-of-type(4) { width: 9% }
       td:nth-of-type(5) { width: 14% }
       td:nth-of-type(6) { width: 9% }

--- a/app/assets/stylesheets/_tables.scss
+++ b/app/assets/stylesheets/_tables.scss
@@ -108,8 +108,8 @@ table.small-table {
     }
     @media (min-width: $small-table-breakpoint) {
       td:nth-of-type(1) { width: 18%; }
-      td:nth-of-type(2) { width: 23% }
-      td:nth-of-type(3) { width: 7.4% }
+      td:nth-of-type(2) { width: 22% }
+      td:nth-of-type(3) { width: 78% }
       td:nth-of-type(4) { width: 9% }
       td:nth-of-type(5) { width: 14% }
       td:nth-of-type(6) { width: 9% }

--- a/app/assets/stylesheets/_tables.scss
+++ b/app/assets/stylesheets/_tables.scss
@@ -109,7 +109,7 @@ table.small-table {
     @media (min-width: $small-table-breakpoint) {
       td:nth-of-type(1) { width: 18%; }
       td:nth-of-type(2) { width: 22% }
-      td:nth-of-type(3) { width: 78% }
+      td:nth-of-type(3) { width: 8% }
       td:nth-of-type(4) { width: 9% }
       td:nth-of-type(5) { width: 14% }
       td:nth-of-type(6) { width: 9% }

--- a/app/assets/stylesheets/tariff-print.scss
+++ b/app/assets/stylesheets/tariff-print.scss
@@ -88,3 +88,22 @@ a[href^="https://"]:after {
 .js-tab-pane {
   display: block !important;
 }
+
+tr.hidden {
+  display: none !important;
+}
+
+span.table-line {
+  display: block !important;
+  & + .table-line {
+    margin-top: 0.5em !important;
+  }
+}
+
+table.measures {
+  border-collapse: collapse;
+  td {
+    border-collapse: collapse;
+    border-bottom: 1px solid #000;
+  }
+}

--- a/app/views/measures/_measure.html.erb
+++ b/app/views/measures/_measure.html.erb
@@ -19,18 +19,27 @@
   </td>
 
   <td class="<%= measure.measure_type.id %>">
-    <%= measure.measure_type.description %>
+    <span class='table-line'><%= measure.measure_type.description %></span>
     <% if measure.order_number.present? %>
-    <br />
-      <%= render measure.order_number %>
+      <span class='table-line'>
+        <%= render measure.order_number %>
+      </span>
+    <% end %>
+    <% if measure.additional_code.present? %>
+      <span class='table-line'>
+        Additional code: <strong><%= measure.additional_code.code %></strong>
+      </span>
+
+      <% if measure.additional_code.formatted_description.present? %>
+        <span class='table-line'>
+          <%= measure.additional_code.formatted_description %>
+        </span>
+      <% end %>
     <% end %>
   </td>
 
   <td class="numerical">
     <%= measure.duty_expression.to_s.html_safe %>
-    <% if measure.additional_code.present? %>
-      Additional code: <%= link_to measure.additional_code,  "##{measure.additional_code.id}", class: 'reference', 'data-popup-ref' => "#{measure.additional_code.id}" %>
-    <% end %>
   </td>
 
   <td>


### PR DESCRIPTION
This PR accomplishes the following:

- Move "Additional code" section of table to the "Measure" column, removing the modal opening functionality
- Making the country list appear below the second column, to avoid confusion between the countries and the description, since they would be displayed alongside
- Tweaking the print styles

Here's a some screenshots with the changes made:

desktop view:
![screen shot 2018-03-02 at 15 59 03](https://user-images.githubusercontent.com/758001/36916452-b2612410-1e32-11e8-87d0-f844fe474cd4.png)


mobile view:
![screen shot 2018-03-02 at 15 50 54](https://user-images.githubusercontent.com/758001/36916322-58bb77bc-1e32-11e8-9ba0-60cc7ce661de.png)

print:
![screen shot 2018-03-02 at 15 24 37](https://user-images.githubusercontent.com/758001/36916341-6514ed72-1e32-11e8-8b1d-844b2efc6d60.png)

and with JS disabled (in this case the country list will be disabled beside the description of second column):
![screen shot 2018-03-02 at 15 51 23](https://user-images.githubusercontent.com/758001/36916379-7a28f046-1e32-11e8-8cbc-fa5f703ec9dd.png)
