### PR TITLE
Fixing country list height issue on measures table

### DIFF
--- a/app/assets/javascripts/commodities.js.erb
+++ b/app/assets/javascripts/commodities.js.erb
@@ -678,6 +678,10 @@
           $(window).on("resize", function() {
             self.enforceHeights();
           });
+
+          $(".js-tabs a").on("click", function() {
+            self.enforceHeights();
+          });
         },
         enforceHeights: function() {
           var windowWidth = $(window).width();
@@ -688,11 +692,15 @@
             table.find("dt.has_children").each(function() {
               var dt = $(this);
               var secondColumn = dt.closest("td").next();
+              var height = 0;
+              secondColumn.find("span.table-line").each(function() {
+                height += $(this).outerHeight();
+              });
 
               if (windowWidth > 839) {
-                dt.css("height", secondColumn.outerHeight() + "px");
+                dt.css("min-height", height + "px");
               } else {
-                dt.css("height", "auto");
+                dt.css("min-height", 0);
               }
             });
           });


### PR DESCRIPTION
Issue was due to two things

1) We were not considering the first column being taller than second
column
2) Before import/export tabs are navigated, the height is not properly
set, so need to listen to their activation to trigger recalculation of
column heights

Tested on IE10, Safari 9+, Firefox and Chrome. Tablets and mobile are not affected since their viewport is different.