### PR TITLE
Remove the redundant Chapter notes heading and remove some commented …

### DIFF
--- a/app/views/commodities/_commodity.html.erb
+++ b/app/views/commodities/_commodity.html.erb
@@ -2,12 +2,6 @@
   <li class="has_children <%= commodity_level(commodity)%><%= leaf_position(commodity) %>">
     <span class="description open without_right_margin" id="commodity-<%= commodity.short_code %>"><%= commodity.to_s.html_safe %></span>
 
-
-<!--     <div class='sub_heading_commodity_code_block pull-right'>
-      <%#= format_commodity_code_based_on_level(commodity) %>
-    </div> -->
-
-
     <ul><%= render commodity.children %></ul>
   </li>
 <% else %>

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -67,8 +67,6 @@
       <h2 class="heading-medium">This commodity has a meursing code</h2>
       <p>Use the <%= link_to "Look up Meursing code", "https://www.gov.uk/additional-commodity-code", rel: "external", target: "_blank", title: "Opens in a new window" %> tool to find the additional code required for importing and exporting. To calculate the duty rate, enter the meursing code (without the 7 at the start) into the <%= link_to "meursing calculator", declarable.meursing_tool_link_for(@search.date.to_taric_date), rel: "external", target: "_blank", title: "Opens in a new window" %>.</p>
     <% end %>
-    <!-- Chapter notes content -->
-    <h2 class="heading-medium">Chapter notes</h2>
     <%= render 'shared/notes', section_note: declarable.section.section_note, chapter_note: declarable.chapter.chapter_note %>
     <h2 class="heading-medium">Binding tariff information</h2>
     <p>You can search the EU EBTI-database for existing <%= link_to "Binding Tariff Information", declarable.bti_url, rel: "external", target: "_blank", title: "Opens in a new window" %> for commodity code <strong><%= declarable.code %></strong>.</p>


### PR DESCRIPTION
Commodity page before :

<img width="971" alt="commodity page before" src="https://user-images.githubusercontent.com/36192669/37169268-7656f696-22d5-11e8-9f33-51540e327b34.png">

Commodity page after :

<img width="981" alt="commodity page after" src="https://user-images.githubusercontent.com/36192669/37169300-932d60de-22d5-11e8-9eca-2d07a8e870d8.png">

Fix observation from @matthewford posted on slack