### PR TITLE
Display the quota description instead of repeating the number

### DIFF
--- a/app/helpers/measures_helper.rb
+++ b/app/helpers/measures_helper.rb
@@ -1,0 +1,5 @@
+module MeasuresHelper
+  def order_number_info(record)
+    record.definition.try(:description) || "Order number #{record.number}"
+  end
+end

--- a/app/models/order_number/definition.rb
+++ b/app/models/order_number/definition.rb
@@ -11,7 +11,7 @@ class OrderNumber
 
     attr_accessor :initial_volume, :status, :measurement_unit,
                   :measurement_unit_qualifier,
-                  :monetary_unit, :balance
+                  :monetary_unit, :balance, :description
 
     DATE_FIELDS.each do |field|
       define_method(field.to_sym) {
@@ -25,6 +25,10 @@ class OrderNumber
 
     def present?
       status.present?
+    end
+
+    def has_description?
+      description.present?
     end
   end
 end

--- a/app/models/order_number/definition.rb
+++ b/app/models/order_number/definition.rb
@@ -26,9 +26,5 @@ class OrderNumber
     def present?
       status.present?
     end
-
-    def has_description?
-      description.present?
-    end
   end
 end

--- a/app/views/order_numbers/_order_number.html.erb
+++ b/app/views/order_numbers/_order_number.html.erb
@@ -3,11 +3,9 @@ Order No: <%= link_to order_number.number, "##{order_number.id}", class: 'refere
   <article>
     <% if order_number.has_definition? %>
       <table>
-        <% if order_number.definition.has_description? %>
-          <caption><%= order_number.definition.description %></caption>
-        <% else %>
-          <caption>Order number <%= order_number.number %>:</caption>
-        <% end %>
+        <caption>
+          <%= order_number_info(order_number) %>
+        </caption>
         <tbody>
           <tr>
             <td>Order Number</td>

--- a/app/views/order_numbers/_order_number.html.erb
+++ b/app/views/order_numbers/_order_number.html.erb
@@ -3,7 +3,11 @@ Order No: <%= link_to order_number.number, "##{order_number.id}", class: 'refere
   <article>
     <% if order_number.has_definition? %>
       <table>
-        <caption>Order number <%= order_number.number %>:</caption>
+        <% if order_number.definition.has_description? %>
+          <caption><%= order_number.definition.description %></caption>
+        <% else %>
+          <caption>Order number <%= order_number.number %>:</caption>
+        <% end %>
         <tbody>
           <tr>
             <td>Order Number</td>


### PR DESCRIPTION
Added some code to check if description is present and then display it instead of repeating the order number.