### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     services:
+      redis:
         image: redis:4.0.10
         ports: ['6379:6379']
         options: --entrypoint redis-server
-
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,83 @@ jobs:
           bundle install --jobs 4 --retry 3 --path vendor/bundle
           bundle exec rails assets:precompile
           RAILS_ENV=test RAILS_DISABLE_TEST_LOG=true bundle exec rspec spec/ --tag '~skip_ci' --profile 10 --format RspecJunitFormatter --out rspec.xml --format progress
+  deploy_dev:
+    if: github.ref == 'refs/heads/master_notyet'
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.5.8
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: '12'
+      - name: "Deploy dev"
+        env:
+          CF_ENDPOINT: "api.london.cloud.service.gov.uk"
+          CF_SPACE: development
+          CF_APP: "tariff-frontend-dev"
+          CF_APP_WORKER: "tariff-frontend-worker-dev"
+          CF_USER: ${{ secrets.CF_USER }}
+          CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
+          CF_ORG: ${{ secrets.CF_ORG }}
+          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          HEALTHCHECK_URL: ${{ secrets.HEALTHCHECK_URL }}
+        run: |
+          curl -v -L -o cf-cli_amd64.deb 'https://cli.run.pivotal.io/stable?release=debian64&source=github'
+          sudo dpkg -i cf-cli_amd64.deb
+          cf -v
+          cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
+          cf install-plugin blue-green-deploy -r CF-Community -f
+          cf install-plugin app-autoscaler-plugin -r CF-Community -f
+          ./bin/deploy
+  deploy_staging:
+    if: github.ref == 'refs/heads/staging_notyet'
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.5.8
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: '12'
+      - name: "Deploy staging"
+        env:
+          CF_ENDPOINT: "api.london.cloud.service.gov.uk"
+          CF_SPACE: staging
+          CF_APP: "tariff-frontend-staging"
+          CF_APP_WORKER: "tariff-frontend-worker-staging"
+          CF_USER: ${{ secrets.CF_USER }}
+          CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
+          CF_ORG: ${{ secrets.CF_ORG }}
+          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          HEALTHCHECK_URL: ${{ secrets.HEALTHCHECK_URL }}
+        run: |
+          curl -v -L -o cf-cli_amd64.deb 'https://cli.run.pivotal.io/stable?release=debian64&source=github'
+          sudo dpkg -i cf-cli_amd64.deb
+          cf -v
+          cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
+          cf install-plugin blue-green-deploy -r CF-Community -f
+          cf install-plugin app-autoscaler-plugin -r CF-Community -f
+          ./bin/deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+        image: redis:4.0.10
+        ports: ['6379:6379']
+        options: --entrypoint redis-server
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.7.1
+      - uses: nanasess/setup-chromedriver@master
+      - name: Build and run tests
+        env:
+          BUNDLER_VERSION: 2.1.4
+          DOCKER_TLS_CERTDIR: ""
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        run: |
+          sudo apt-get update -qy
+          sudo apt-get install -y build-essential rake
+          gem install bundler --version "<= $BUNDLER_VERSION"
+          bundle install --jobs 4 --retry 3 --path vendor/bundle
+          bundle exec rails assets:precompile
+          RAILS_ENV=test RAILS_DISABLE_TEST_LOG=true bundle exec rspec spec/ --tag '~skip_ci' --profile 10 --format RspecJunitFormatter --out rspec.xml --format progress

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -1,0 +1,43 @@
+name: "Production deployment"
+on: [workflow_dispatch]
+jobs:
+  deploy_production:
+    if: github.ref == 'refs/heads/production_notyet'
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.5.8
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: '12'
+      - name: "Deploy production"
+        env:
+          CF_ENDPOINT: "api.london.cloud.service.gov.uk"
+          CF_SPACE: production
+          CF_APP: "tariff-frontend-production"
+          CF_APP_WORKER: "tariff-frontend-worker-production"
+          CF_USER: ${{ secrets.CF_USER }}
+          CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
+          CF_ORG: ${{ secrets.CF_ORG }}
+          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          HEALTHCHECK_URL: ${{ secrets.HEALTHCHECK_URL }}
+        run: |
+          curl -v -L -o cf-cli_amd64.deb 'https://cli.run.pivotal.io/stable?release=debian64&source=github'
+          sudo dpkg -i cf-cli_amd64.deb
+          cf -v
+          cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
+          cf install-plugin blue-green-deploy -r CF-Community -f
+          cf install-plugin app-autoscaler-plugin -r CF-Community -f
+          ./bin/deploy


### PR DESCRIPTION
This PR migrates from Gitlab CI to Github Actions.

Like in the backend app, the deployment steps have wrong branches to prevent deployment, since secrets are not in place yet, so we want to avoid issues with PaaS.

Until then, there is value in seeing specs running in CI.