### PR TITLE
Update forum link url

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -103,7 +103,7 @@ module ApplicationHelper
     if chapter.forum_url.present?
       chapter.forum_url
     else
-      "https://forum.trade-tariff.service.gov.uk/c/classification-#{chapter.short_code}"
+      "https://forum.trade-tariff.service.gov.uk/c/classification/chapter-#{chapter.short_code}"
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -103,7 +103,7 @@ module ApplicationHelper
     if chapter.forum_url.present?
       chapter.forum_url
     else
-      "https://forum.trade-tariff.service.gov.uk/c/classification/#{chapter.short_code}"
+      "https://forum.trade-tariff.service.gov.uk/c/classification-#{chapter.short_code}"
     end
   end
 


### PR DESCRIPTION
The link to the chapter discussions in the forum are incorrect and the `/` should be replaced with '-' in the url.

Asana: https://app.asana.com/0/1199180449660757/1199185353011086/f

