### PR TITLE
Ensure email parameters for SES are valid

### DIFF
--- a/app/mailers/frontend_mailer.rb
+++ b/app/mailers/frontend_mailer.rb
@@ -4,8 +4,8 @@ class FrontendMailer < ActionMailer::Base
 
   def new_feedback(message, name = nil, email = nil)
     @message = message
-    @name = name
-    @email = email
+    @name = name.presence || nil
+    @email = email.presence || TradeTariffFrontend.from_email
 
     mail subject: "Trade Tariff Feedback",
          reply_to: @email


### PR DESCRIPTION
- reply_to: must have an email address; the value cannot be empty if this parameter is used
- name: set @name (used in email message template) to `nil` instead of a blank string, which causes a small rendering bug in the email body (i.e. a comma `,` may be printed even if no name is provided)

![Screen Shot 2020-11-19 at 12 55 39 PM](https://user-images.githubusercontent.com/740379/99704912-080d0080-2a67-11eb-9dcc-dc5fd144b35c.png)
