### PR TITLE
Filter bad query params

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -101,5 +101,8 @@ module TradeTariffFrontend
     config.x.http.max_retry = 5
 
     config.middleware.use Rack::Attack
+
+    # Prevent invalid queries from causing an error, e.g., `/api/v2/search_references.json?query[letter]=%`
+    config.middleware.use TradeTariffFrontend::FilterBadQueryParameterEncoding
   end
 end

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -102,4 +102,29 @@ module TradeTariffFrontend
       end
     end
   end
+
+  class FilterBadQueryParameterEncoding
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      @query_string = env['QUERY_STRING'].to_s
+      begin
+        Rack::Utils.parse_nested_query @query_string
+      rescue Rack::Utils::InvalidParameterError
+        return bad_request
+      end
+
+      @app.call(env)
+    end
+
+    def bad_request
+      [
+        400,
+        { "Content-Type" => "application/json" },
+        [{ status: 400, error: "There was a problem with your query: '#{@query_string}'" }.to_json]
+      ]
+    end
+  end
 end

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -120,10 +120,25 @@ module TradeTariffFrontend
     end
 
     def bad_request
+      @status = 400
       [
-        400,
-        { "Content-Type" => "application/json" },
-        [{ status: 400, error: "There was a problem with your query: '#{@query_string}'" }.to_json]
+        @status,
+        { 'Content-Type' => 'application/json' },
+        error_object
+      ]
+    end
+
+    def error_object
+      [
+        {
+          errors: [
+            {
+              status: @status.to_s,
+              title: "There was a problem with your query",
+              source: {parameter: @query_string}
+            }
+          ]
+        }.to_json
       ]
     end
   end

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -134,8 +134,8 @@ module TradeTariffFrontend
           errors: [
             {
               status: @status.to_s,
-              title: "There was a problem with your query",
-              source: {parameter: @query_string}
+              title: 'There was a problem with your query',
+              source: { parameter: @query_string }
             }
           ]
         }.to_json


### PR DESCRIPTION
An error is triggered, when certain characters are in a request query string. This results in an ugly 500 error that is displayed to the client. We can't catch this in the controller, since it occurs in Rack. Instead, we should catch this error in middleware and return a 400 Bad Request response.

- certain characters (e.g. "%") cause errors when parsed by `URI.decode_www_form_component`
- implement a middleware class to parse the request query string and return 400 Bad Request if the request query string fails to parse (instead of 500 Error)

Sentry error: https://sentry.io/organizations/bit-zesty-client-apps/issues/2010483718/?project=78658
Asana: https://app.asana.com/0/1199180449660757/1198831871282498/f