### PR TITLE
Do not cache backend API errors

### DIFF
--- a/lib/trade_tariff_frontend/request_forwarder.rb
+++ b/lib/trade_tariff_frontend/request_forwarder.rb
@@ -80,7 +80,7 @@ module TradeTariffFrontend
 
     def cache_control_string(response)
       is_error = response.status.to_i.between?(500, 599)
-      cache_control = ["max-age=#{is_error ? 0 : 3600}#{}"]
+      cache_control = ["max-age=#{is_error ? 0 : 3600}"]
       cache_control.unshift('no-store') if is_error
       cache_control.join(', ')
     end

--- a/lib/trade_tariff_frontend/request_forwarder.rb
+++ b/lib/trade_tariff_frontend/request_forwarder.rb
@@ -41,7 +41,7 @@ module TradeTariffFrontend
             response.headers.
                      except(*IGNORED_UPSTREAM_HEADERS).
                      merge('X-Slimmer-Skip' => true).
-                     merge('Cache-Control' => "max-age=#{response.status.to_i.between?(500, 599) ? 180 : 3600}")
+                     merge('Cache-Control' => cache_control_string(response))
           )
         ).finish
       else
@@ -76,6 +76,13 @@ module TradeTariffFrontend
     def api_request_path_for(path)
       @uri = URI.parse(path)
       @api_request_path_formatter.call(path)
+    end
+
+    def cache_control_string(response)
+      is_error = response.status.to_i.between?(500, 599)
+      cache_control = ["max-age=#{is_error ? 0 : 3600}#{}"]
+      cache_control.unshift('no-store') if is_error
+      cache_control.join(', ')
     end
   end
 end


### PR DESCRIPTION
- When an API request on the FE results in a 5XX error from the backend, set "Cache-Control" HTTP header to `no-store, max-age=0`
- "The no-store directive will prevent a new resource being cached, but it will not prevent the cache from responding with a non-stale resource that was cached as the result of an earlier request. Setting max-age=0 as well forces the cache to revalidate (clears the cache)."
- see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Examples
- Asana: https://app.asana.com/0/1199180449660757/1199221802948507/f