### PR TITLE
Add spec to cover post-EU-Exit search dates

### DIFF
--- a/spec/features/date_currency_change_spec.rb
+++ b/spec/features/date_currency_change_spec.rb
@@ -55,11 +55,22 @@ describe "Date & Currency change", js: true, vcr: {
 
   it 'displays the searched-for date, if the searched-for date is past BREXIT_DATE, and the current date is past BREXIT_DATE' do
     post_eu_exit_date = DateTime.new(2021, 1, 1, 12, 0, 0)
+    searched_for_date = DateTime.new(2021, 2, 2, 12, 0, 0)
 
     Timecop.freeze(post_eu_exit_date) do
       visit sections_path
 
-      expect(page).to have_content "This tariff is for #{post_eu_exit_date.strftime('%-d %B %Y')}"
+      expect(page).to have_content "This tariff is for #{(post_eu_exit_date).strftime('%-d %B %Y')}"
+
+      click_link 'Change date'
+
+      page.execute_script("$('#tariff_date_year').val('#{searched_for_date.year}')")
+      page.execute_script("$('#tariff_date_month').val('#{searched_for_date.month}')")
+      page.execute_script("$('#tariff_date_day').val('#{searched_for_date.day}')")
+
+      click_link 'Set date'
+
+      expect(page).to have_content "This tariff is for #{(searched_for_date).strftime('%-d %B %Y')}"
     end
   end
 end

--- a/spec/features/date_currency_change_spec.rb
+++ b/spec/features/date_currency_change_spec.rb
@@ -32,24 +32,21 @@ describe "Date & Currency change", js: true, vcr: {
   end
 
   it 'displays today\'s date, if the searched-for date is past BREXIT_DATE, but the current date is before BREXIT_DATE' do
-    now = DateTime.new(2020, 11, 23, 12, 0, 0)
-    eu_exit = Date.parse(ENV['BREXIT_DATE'] || '2021-01-01')
+    pre_eu_exit_date = DateTime.new(2020, 12, 31, 12, 0, 0)
+    searched_for_date = DateTime.new(2021, 2, 2, 12, 0, 0)
 
-    visit sections_path(day: now.yesterday.day, month: now.month, year: now.year)
+    Timecop.freeze(pre_eu_exit_date) do
+      visit sections_path
 
-    expect(page).to have_content "This tariff is for #{now.yesterday.strftime('%-d %B %Y')}"
+      click_link 'Change date'
 
-    click_link 'Change date'
+      page.execute_script("$('#tariff_date_year').val('#{searched_for_date.year}')")
+      page.execute_script("$('#tariff_date_month').val('#{searched_for_date.month}')")
+      page.execute_script("$('#tariff_date_day').val('#{searched_for_date.day}')")
 
-    page.execute_script("$('#tariff_date_year').val('#{eu_exit.year}')")
-    page.execute_script("$('#tariff_date_month').val('#{eu_exit.month}')")
-    page.execute_script("$('#tariff_date_day').val('#{eu_exit.day + 1}')")
-
-    Timecop.freeze(now) do
       click_link 'Set date'
 
-      expect(page).to have_content "This tariff is for #{now.strftime('%-d %B %Y')}"
-      expect(page).to have_content "Change date"
+      expect(page).to have_content "This tariff is for #{(pre_eu_exit_date).strftime('%-d %B %Y')}"
     end
   end
 

--- a/spec/features/date_currency_change_spec.rb
+++ b/spec/features/date_currency_change_spec.rb
@@ -52,4 +52,14 @@ describe "Date & Currency change", js: true, vcr: {
       expect(page).to have_content "Change date"
     end
   end
+
+  it 'displays the searched-for date, if the searched-for date is past BREXIT_DATE, and the current date is past BREXIT_DATE' do
+    post_eu_exit_date = DateTime.new(2021, 1, 1, 12, 0, 0)
+
+    Timecop.freeze(post_eu_exit_date) do
+      visit sections_path
+
+      expect(page).to have_content "This tariff is for #{post_eu_exit_date.strftime('%-d %B %Y')}"
+    end
+  end
 end

--- a/spec/features/date_currency_change_spec.rb
+++ b/spec/features/date_currency_change_spec.rb
@@ -54,13 +54,11 @@ describe "Date & Currency change", js: true, vcr: {
   end
 
   it 'displays the searched-for date, if the searched-for date is past BREXIT_DATE, and the current date is past BREXIT_DATE' do
-    post_eu_exit_date = DateTime.new(2021, 1, 1, 12, 0, 0)
+    post_eu_exit_date = DateTime.new(2021, 1, 2, 12, 0, 0)
     searched_for_date = DateTime.new(2021, 2, 2, 12, 0, 0)
 
     Timecop.freeze(post_eu_exit_date) do
       visit sections_path
-
-      expect(page).to have_content "This tariff is for #{(post_eu_exit_date).strftime('%-d %B %Y')}"
 
       click_link 'Change date'
 

--- a/spec/features/date_currency_change_spec.rb
+++ b/spec/features/date_currency_change_spec.rb
@@ -31,25 +31,6 @@ describe "Date & Currency change", js: true, vcr: {
     expect(page).to have_content "Change date"
   end
 
-  it 'displays today\'s date, if the searched-for date is past BREXIT_DATE, but the current date is before BREXIT_DATE' do
-    pre_eu_exit_date = DateTime.new(2020, 12, 31, 12, 0, 0)
-    searched_for_date = DateTime.new(2021, 2, 2, 12, 0, 0)
-
-    Timecop.freeze(pre_eu_exit_date) do
-      visit sections_path
-
-      click_link 'Change date'
-
-      page.execute_script("$('#tariff_date_year').val('#{searched_for_date.year}')")
-      page.execute_script("$('#tariff_date_month').val('#{searched_for_date.month}')")
-      page.execute_script("$('#tariff_date_day').val('#{searched_for_date.day}')")
-
-      click_link 'Set date'
-
-      expect(page).to have_content "This tariff is for #{(pre_eu_exit_date).strftime('%-d %B %Y')}"
-    end
-  end
-
   it 'displays the searched-for date, if the searched-for date is past BREXIT_DATE, and the current date is past BREXIT_DATE' do
     post_eu_exit_date = DateTime.new(2021, 1, 2, 12, 0, 0)
     searched_for_date = DateTime.new(2021, 2, 2, 12, 0, 0)


### PR DESCRIPTION
- if the searched-for date is past BREXIT_DATE, and the current date is past BREXIT_DATE, then the searched-for date should show

Asana: [TARIFF0520] Quey/Bug from Daniel Clarke - re date setting, https://app.asana.com/0/1199180449660757/1198723048518973/f