### PR TITLE
Allow setting a simulation date to default the view at a specific date in time

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,7 +29,7 @@ class ApplicationController < ActionController::Base
   def url_options
     return super unless search_invoked?
 
-    if search_query.date.today?
+    if search_query.date.today? || search_query.date == TradeTariffFrontend.simulation_date
       return { country: search_query.country, currency: search_query.currency }.merge(super)
     end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -66,7 +66,7 @@ module ApplicationHelper
   end
 
   def currency_options
-    [%w[Pound \sterling GBP], %w[Euro EUR]]
+    [%w[Pound\ sterling GBP], %w[Euro EUR]]
   end
 
   def download_chapter_pdf_url(section_position, chapter_code)

--- a/app/models/tariff_date.rb
+++ b/app/models/tariff_date.rb
@@ -14,6 +14,8 @@ class TariffDate
     new(
       if valid_date_param?(date_param)
         date_param.values_at(*DATE_KEYS).join('-')
+      elsif TradeTariffFrontend.simulation_date
+        TradeTariffFrontend.simulation_date
       else
         Date.current
       end

--- a/app/models/tariff_date.rb
+++ b/app/models/tariff_date.rb
@@ -35,7 +35,7 @@ class TariffDate
   end
 
   def date
-    date.presence || TradeTariffFrontend.simulation_date || TariffUpdate.latest_applied_import_date
+    @date.presence || TradeTariffFrontend.simulation_date || TariffUpdate.latest_applied_import_date
   end
 
   def persisted?

--- a/app/models/tariff_date.rb
+++ b/app/models/tariff_date.rb
@@ -35,7 +35,7 @@ class TariffDate
   end
 
   def date
-    @date.presence || TariffUpdate.latest_applied_import_date
+    date.presence || TradeTariffFrontend.simulation_date || TariffUpdate.latest_applied_import_date
   end
 
   def persisted?

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -59,6 +59,10 @@ module TradeTariffFrontend
     currency_default_gbp? ? "GBP" : "EUR"
   end
 
+  def simulation_date
+    ENV.fetch("SIMULATION_DATE", nil)
+  end
+  
   def uk_regulations_enabled?
     ENV.fetch('UK_REGULATIONS', 'false').to_s.downcase == 'true'
   end


### PR DESCRIPTION
Using the SIMULATION_DATE environment variable.

This should be unset on production but is useful in other envs for testing.