### PR TITLE
Increasing width a bit due to change to Pound Sterling wording

### DIFF
--- a/app/webpacker/src/stylesheets/_header.scss
+++ b/app/webpacker/src/stylesheets/_header.scss
@@ -6,13 +6,13 @@
   .searchfield {
     position: relative;
 
-    max-width: 70ex;
+    max-width: 85ex;
   }
 
   .select2-selection__arrow {
     display: none;
   }
-  
+
   .search-submit {
     position: absolute;
     bottom: 0;


### PR DESCRIPTION
When we changed the word of currency to Pound sterling, whenever the env var to enable to currency sweitching is on, it causes a line break.

This PR simply increases the width of the container to accomodate the longer name on the same line.

Card: https://app.asana.com/0/1199164317302737/1199656939215444

ps: I was not able to reproduce the issue in the first screenshot, where the currency name looks broken and "sunken"...

---

![Selection_377](https://user-images.githubusercontent.com/758001/102935825-cb398c80-449e-11eb-97f2-8ae85865ad1a.png)
![Selection_375](https://user-images.githubusercontent.com/758001/102935831-cd035000-449e-11eb-8774-2b577baa1764.png)
